### PR TITLE
fix: remove unnecessary and faulty mount command from `devcontainer.json`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,9 +16,6 @@
 	"forwardPorts": [
 		5000
 	],
-	"mounts": [
-		"source=${localWorkspaceFolder}/config/ssh-key/container_shutdown_key,target=/etc/ssh/shutdown_key,type=bind,readonly"
-	],
 	"containerEnv": {
 		"DEV_MODE": "1"
 	}


### PR DESCRIPTION
Originally, the SSH key needed for the shutdown procedure was mounted to the container. This didn't really work and was removed from the Docker file. This PR removes the leftovers of the original approach  from `devcontainer.json`.