### PR TITLE
feat: add reset button to reload the page

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -20,6 +20,7 @@
     <div class="actions">
       <button type="button" onclick="addLabel()">➕ Add Label</button>
       <button type="submit">🖨️ Print</button>
+      <button type="button" onclick="reloadLocation()">&circlearrowleft; Reset</button>
     </div>
   </form>
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -19,6 +19,11 @@ function addLabel() {
   labelCount++;
 }
 
+// Reload the page after clicking the "Reset" button
+function reloadLocation() {
+  location.reload();
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   addLabel();
 


### PR DESCRIPTION
To reset the page to its original state (one label, four lines, and placeholder texts), after e.g. adding multiple lines, the user had to reload the page by keyboard shortcut or by clicking on the browser's refresh icon. This PR adds an "Reset" button next to the "Print" button to do the same thing but is maybe a bit more intuitive. 