### PR TITLE
add missing printables link in  README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The following needs to be in `devcontainer.json`:
 ```
 
 ## Optional: PTouch P700 Stand
-I designed a 3D-printable stand for the PTouch P700 and a Raspberry Pi. The model is available on [Printables](TODO).
+I designed a 3D-printable stand for the PTouch P700 and a Raspberry Pi. The model is available on [Printables](https://www.printables.com/model/1324678-p-touch-p700-and-rasperry-pi-stand-simple-label-pr).
 ![Ptouch P700 stand](docs/images/P700_Raspi_stand.jpg)
 
 ## Known issues


### PR DESCRIPTION
The link to the 3D printing files on Printables was missing and now added.